### PR TITLE
Add dashboard welcome username and not logged in user sad path

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,10 @@
 class DashboardController < ApplicationController
   def index
+    if current_user
+      flash[:success] = "Welcome, #{current_user.name}"
+    else
+      flash[:notice] = "You Must Log In To Visit Your Dashboard"
+      redirect_to login_path
+    end
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,10 +1,14 @@
 class DashboardController < ApplicationController
   def index
-    if current_user
-      flash[:success] = "Welcome, #{current_user.name}"
-    else
-      flash[:notice] = "You Must Log In To Visit Your Dashboard"
-      redirect_to login_path
-    end
+    return not_logged_in_notice unless current_user
+
+    flash[:success] = "Welcome, #{current_user.name}"
+  end
+
+  private
+
+  def not_logged_in_notice
+    flash[:notice] = 'You Must Log In To Visit Your Dashboard'
+    redirect_to login_path
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,7 +1,7 @@
 class WelcomeController < ApplicationController
   def index
-    if current_user
-      redirect_to dashboard_path
-    end
+    return unless current_user
+
+    redirect_to dashboard_path
   end
 end

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -2,35 +2,61 @@ require 'rails_helper'
 
 RSpec.describe('Dashboard') do
   describe 'happy path' do
-    before :each do
-      visit dashboard_path
+    describe 'as an authenticated user' do
+      before :each do
+        @user = User.create(name: 'Buffy', email: "buffyslayer@example.com", password: "test")
+
+        visit login_path
+
+        fill_in :email, with: @user.email.upcase
+        fill_in :name, with: @user.name.upcase
+        fill_in :password, with: @user.password
+
+        click_button 'Log In'
+
+        # Logging In Redirects to Dashboard
+      end
+
+      it "should display 'Welcome <username>!' at the top of page" do
+        expect(page).to have_content("Welcome, #{@user.name}")
+      end
+
+      it "should have a button to 'Discover Movies'" do
+        expect(page).to have_button('Discover Movies')
+      end
+
+      it 'should have a friends section' do
+        expect(page).to have_content('My Friends:')
+        expect(page).to have_selector("section[class='friends']")
+      end
+
+      it 'should have a viewing parties section' do
+        expect(page).to have_content('My Viewing Parties:')
+        expect(page).to have_selector("section[class='viewing-parties']")
+      end
+
+      describe "when a user clicks the 'Discover Movies' button" do
+        it 'they should be taken to the discover movies page /discover' do
+          click_button 'Discover Movies'
+
+          expect(current_path).to eq(discover_path)
+        end
+      end
     end
+  end
 
-    it "should display 'Welcome <username>!' at the top of page" do
-      skip
+  describe 'sad path' do
+    describe 'when I am NOT an authenticated user' do
+      before :each do
+        visit dashboard_path
+      end
 
-      expect(page).to have_content('Welcome Ryan!')
-    end
+      it 'should redirect back to the log in page' do
+        expect(current_path).to eq(login_path)
+      end
 
-    it "should have a button to 'Discover Movies'" do
-      expect(page).to have_button('Discover Movies')
-    end
-
-    it 'should have a friends section' do
-      expect(page).to have_content('My Friends:')
-      expect(page).to have_selector("section[class='friends']")
-    end
-
-    it 'should have a viewing parties section' do
-      expect(page).to have_content('My Viewing Parties:')
-      expect(page).to have_selector("section[class='viewing-parties']")
-    end
-
-    describe "when a user clicks the 'Discover Movies' button" do
-      it 'they should be taken to the discover movies page /discover' do
-        click_button 'Discover Movies'
-
-        expect(current_path).to eq(discover_path)
+      it "should give a 'You Must Log In To Visit Your Dashboard' notice" do
+        expect(page).to have_content('You Must Log In To Visit Your Dashboard')
       end
     end
   end


### PR DESCRIPTION
In the happy path before each I am actually going to the log in page and logging in as Buffy. I was tired and didn't want to figure out the nice way so any input on that is super helpful.

Also the sad path wasn't in the user story but I thought it made sense to have.