### PR TITLE
Ryan dashboard friends spike

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,0 +1,8 @@
+class FriendshipsController < ApplicationController
+  def create
+    # binding.pry
+    wannabe_friend = User.find_by(email: params[:email])
+    current_user.friendships.create!({friend_id: wannabe_friend.id})
+    redirect_to dashboard_path
+  end
+end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,8 +1,7 @@
 class FriendshipsController < ApplicationController
   def create
-    # binding.pry
-    wannabe_friend = User.find_by(email: params[:email])
-    current_user.friendships.create!({friend_id: wannabe_friend.id})
+    friend = User.find_by(email: params[:email])
+    current_user.friendships.create!({ friend_id: friend.id })
     redirect_to dashboard_path
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,8 +16,9 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    current_user.destroy
-    session[:user_id] = nil
+    # current_user.destroy
+    reset_session
+    # session[:user_id] = nil
     redirect_to root_path, notice: 'Log Out Successful'
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,9 +16,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    # current_user.destroy
     reset_session
-    # session[:user_id] = nil
     redirect_to root_path, notice: 'Log Out Successful'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,16 +4,14 @@ class UsersController < ApplicationController
   end
 
   def create
-    user = user_params
-    user[:email] = user[:email].downcase
-    # @new_user = User.new(user)
-    if user[:password] != "" && user[:password] == user[:password_confirmation]
-      new_user = User.create(user)
+    user_params[:email] = user_params[:email].downcase
+    if user_params[:password] != '' && user_params[:password] == user_params[:password_confirmation]
+      new_user = User.create(user_params)
       session[:user_id] = new_user.id
       flash[:success] = "Welcome, #{new_user.name}"
       redirect_to dashboard_path
     else
-      flash[:error] = "Your credentials need soem work bruh"
+      flash[:error] = 'Your credentials need soem work bruh'
       redirect_to new_user_path
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_many :friendships, dependent: :destroy
   has_many :friends, through: :friendships
-  has_many :viewers
+  has_many :viewers, dependent: :destroy
   has_many :parties, through: :viewers
 
   validates :email, uniqueness: true, presence: true

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,11 +1,26 @@
 <%= button_to 'Discover Movies', discover_path, method: "get" %>
 
 <section class='friends'>
-  <h2>My Friends:</h2>
+  <h2>Add a Friend:</h2>
+  <%= form_with url: friendships_path, local: true do |form| %>
+    <%= form.label :email %>
+    <%= form.email_field :email %>
 
+    <%= form.submit 'Add Friend' %>
+  <% end %>
+
+  <h2>My Friends:</h2>
+  <% unless @current_user.friends.empty? %>
+    <ul>
+      <% @current_user.friends.each do |friend| %>
+        <li><%= friend.name %></li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p>You currently have no friends</p>
+  <% end %>
 </section>
 
 <section class='viewing-parties'>
   <h2>My Viewing Parties:</h2>
-
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,13 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  
+
   root 'welcome#index'
-  
+
   resources :movies, only: [:index]
 
   resources :users, only: [:new, :create]
+  
+  resources :friendships, only: [:create]
 
   get '/dashboard', to: 'dashboard#index'
   get '/discover', to: 'discover#index'

--- a/db/migrate/20210204222741_update_friendships.rb
+++ b/db/migrate/20210204222741_update_friendships.rb
@@ -1,0 +1,5 @@
+class UpdateFriendships < ActiveRecord::Migration[5.2]
+  def change
+    change_column :friendships, :status, :integer, default: 'pending'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_03_005509) do
+ActiveRecord::Schema.define(version: 2021_02_04_222741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2021_02_03_005509) do
   create_table "friendships", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "friend_id"
-    t.integer "status"
+    t.integer "status", default: 0
     t.index ["friend_id"], name: "index_friendships_on_friend_id"
     t.index ["user_id"], name: "index_friendships_on_user_id"
   end

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -30,6 +30,53 @@ RSpec.describe('Dashboard') do
         expect(page).to have_selector("section[class='friends']")
       end
 
+      describe 'inside the friends section' do
+        it "should have a text field to enter a friend's email" do
+          within '.friends' do
+            expect(page).to have_field("email")
+          end
+        end
+
+        it "should have a button to 'Add Friend'" do
+          within '.friends' do
+            expect(page).to have_button('Add Friend')
+          end
+        end
+
+
+        describe 'friendship happy path' do
+          describe "when I fill in the add friend form with a user's email and click 'Add Friend'" do
+            before :each do
+              @other_user = User.create(name: 'other', email: "otheruser@example.com", password: "otherpassword")
+
+              within '.friends' do
+                fill_in 'email', with: @other_user.email
+
+                click_button 'Add Friend'
+              end
+            end
+
+            it 'I should be redirected to my dashboard' do
+              expect(current_path).to eq(dashboard_path)
+            end
+
+            it "I should see my friend's name in my list of friends" do
+              within '.friends' do
+                expect(page).to have_content(@other_user.name)
+              end
+            end
+          end
+        end
+
+        describe 'if I have not added any friends' do
+          it 'there should be a message "You currently have no friends"' do
+            within '.friends' do
+              expect(page).to have_content('You currently have no friends')
+            end
+          end
+        end
+      end
+
       it 'should have a viewing parties section' do
         expect(page).to have_content('My Viewing Parties:')
         expect(page).to have_selector("section[class='viewing-parties']")


### PR DESCRIPTION
Adds:

- friend form/list happy tests
- friendships create route
- friendships controller w create action
- a friend form and friends list to dashboard index view


Changes:

- newly created friendships have a default status of pending
- session controller destroy action uses `reset_session` instead of current_user.destroy session[:user_id] = nil
- shortened users controller create action to below 10 lines to pass rubocop