### PR TITLE
Dashboard friends sad paths

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,7 +1,17 @@
 class FriendshipsController < ApplicationController
   def create
     friend = User.find_by(email: params[:email])
-    current_user.friendships.create!({ friend_id: friend.id })
-    redirect_to dashboard_path
+    if friend
+      if friend.id == current_user.id
+        redirect_to dashboard_path, notice: 'Failed Friend Request. Cannot Friend Yourself!'
+      elsif current_user.friends.include?(friend)
+        redirect_to dashboard_path, notice: "Failed Friend Request. Already Friended User: #{friend.name}"
+      else
+        current_user.friendships.create!({ friend_id: friend.id })
+        redirect_to dashboard_path
+      end
+    else
+      redirect_to dashboard_path, notice: "Failed Friend Request. Unable to find user with email: #{params[:email]}'"
+    end
   end
 end

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -68,6 +68,54 @@ RSpec.describe('Dashboard') do
           end
         end
 
+        describe 'friendship sad path' do
+          describe 'when I fill in the add friend form with an email that does not correspond to a user' do
+            it "I should see a notice that says 'Unable to find user with email: <email>'" do
+              wrong_email = 'wrong@email.com'
+
+              within '.friends' do
+                fill_in 'email', with: wrong_email
+
+                click_button 'Add Friend'
+              end
+
+              expect(page).to have_content("Failed Friend Request. Unable to find user with email: #{wrong_email}'")
+            end
+          end
+
+          describe 'when I fill in the add friend form with my own email' do
+            it "I should see a notice that says 'Failed Friend Request. Cannot Friend Yourself.'" do
+              within '.friends' do
+                fill_in 'email', with: @user.email
+
+                click_button 'Add Friend'
+              end
+
+              expect(page).to have_content("Failed Friend Request. Cannot Friend Yourself!")
+            end
+          end
+
+          describe "when I fill in the add friend form with a previously friended user's email" do
+            before :each do
+              @other_user = User.create(name: 'other', email: "otheruser@example.com", password: "otherpassword")
+
+              within '.friends' do
+                fill_in 'email', with: @other_user.email
+
+                click_button 'Add Friend'
+                
+                fill_in 'email', with: @other_user.email
+
+                click_button 'Add Friend'
+              end
+            end
+
+            it "I should see a notice that says 'Failed Friend Request. Already Friended User: <user name>'" do
+              expect(page).to have_content("Failed Friend Request. Already Friended User: #{@other_user.name}")
+            end
+          end
+        end
+
         describe 'if I have not added any friends' do
           it 'there should be a message "You currently have no friends"' do
             within '.friends' do


### PR DESCRIPTION
**All tests are passing but there is a rubocop Metrics/MethodLength: Method has too many lines. warning. Any ideas on how to refactor the friendships controller create action to have fewer lines is appreciated.**

While doing this I also realized there should be a happy path success message. So that is something to add in the future but not mandatory.

Adds 3 dashboard add friend form sad path tests and updates friendships controller to handle them.

- Can't friend yourself
- Can't friend someone more than once
- Can't friend someone if the provided email doesn't match any registered users