### PR TITLE
Movie details runtime

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,11 +1,7 @@
 class MoviesController < ApplicationController
   def index
     block_public_access
-    if params[:search].present?
-      @films = MovieDbFacade.search_films(params[:search])
-    else
-      @films = MovieDbFacade.discover_films
-    end
+    @films = params[:search].present? ? MovieDbFacade.search_films(params[:search]) : MovieDbFacade.discover_films
   end
 
   def show

--- a/app/facades/movie_db_facade.rb
+++ b/app/facades/movie_db_facade.rb
@@ -9,15 +9,13 @@ class MovieDbFacade
       json = MovieDbService.call_search_films(query)
       create_films(json)
     end
- 
+
     def get_movie_info(mdb_id)
       json = MovieDbService.call_movie_info(mdb_id)
       @film = Film.new(json)
     end
 
-  # rubocop:  private is 'useles' ... does not make singleton methods private. 
-  # Use private_class_method or private inside a class << self block instead.
-  private
+    private
 
     def create_films(json)
       json[:results].map do |film_data|

--- a/app/poros/film.rb
+++ b/app/poros/film.rb
@@ -24,4 +24,12 @@ class Film
   def list_genres
     genres.map { |genre| genre[:name] }.join(', ')
   end
+
+  def runtime_hours
+    (@runtime / 60).floor
+  end
+
+  def runtime_minutes
+    @runtime % 60
+  end
 end

--- a/app/poros/film.rb
+++ b/app/poros/film.rb
@@ -6,7 +6,7 @@ class Film
               :genres,
               :overview,
               :credits
-  # RYAN - I added cast above and below. An alternative is to make an actor poros to create separately.
+
   def initialize(attributes)
     @id = attributes[:id]
     @title = attributes[:title]
@@ -16,7 +16,7 @@ class Film
     @overview = attributes[:overview]
     @credits = attributes[:credits]
   end
-  # RYAN NEEDED TO MAKE SEPARATE METHODS TO AVOID NIL ERRORS. Dream Drive!
+
   def cast
     credits[:cast].map { |member| [member[:name], member[:character]] }
   end

--- a/app/services/movie_db_service.rb
+++ b/app/services/movie_db_service.rb
@@ -17,6 +17,7 @@ class MovieDbService
     end
 
     private
+
     # RYAN - I ended up just adding line 20 (below) to get credits
     def movie_info(mdb_id)
       response = conn.get("movie/#{mdb_id}") do |req|

--- a/app/views/movies/show.html.erb
+++ b/app/views/movies/show.html.erb
@@ -5,7 +5,7 @@
 <ul>
   <li>
     <p>Vote Average: <%= @movie.vote_average %></p>
-    <p>Runtime: <%= @movie.runtime %></p>
+    <p>Runtime: <%= @movie.runtime_hours %> Hour(s) <%= @movie.runtime_minutes %> Minute(s)</p>
     <p>Genres: <%= @movie.list_genres %></p>
     <p>Summary: <%= @movie.overview %></p>
     <p>Cast: </p>

--- a/spec/features/movies/show_spec.rb
+++ b/spec/features/movies/show_spec.rb
@@ -1,31 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe 'movies show page', type: :feature do
-    describe 'as a user' do
-        before(:each) do
-            # REPLACE THIS WITH WEBMOCK AND STUB
-            @movie = Movie.create!(mdb_id: '2')
-            @movie_info = MovieDbFacade.get_movie_info(@movie.mdb_id)
-            visit movie_path(@movie.id)
-        end
-
-        describe "happy path" do
-            it "displays movie information from movie API path" do
-                expect(page).to have_content(@movie_info.title)
-                expect(page).to have_content("Vote Average: #{@movie_info.vote_average}")
-                expect(page).to have_content("Runtime: #{@movie_info.runtime}")
-                expect(page).to have_content("Genres: Drama, Crime, Comedy")
-                expect(page).to have_content("Summary: Taisto Kasurinen is a Finnish coal miner whose father has just committed suicide and who is framed for a crime he did not commit. In jail, he starts to dream about leaving the country and starting a new life. He escapes from prison but things don't go as planned...")
-            end
-
-            it "displays cast information" do
-                expect(page).to have_content('Turo Pajala as Taisto Olavi Kasurinen')
-                expect(page).to have_content('Susanna Haavisto as Irmeli Katariina Pihlaja')
-                expect(page).to_not have_content('Adam as Professor Etz')
-            end
-
-            xit "displays review informtion" do
-            end
-        end
+  describe 'as a user' do
+    before(:each) do
+      # REPLACE THIS WITH WEBMOCK AND STUB
+      @movie = Movie.create!(mdb_id: '2')
+      @movie_info = MovieDbFacade.get_movie_info(@movie.mdb_id)
+      visit movie_path(@movie.id)
     end
+
+    describe "happy path" do
+      it "displays movie information from movie API path" do
+        expect(page).to have_content(@movie_info.title)
+        expect(page).to have_content("Vote Average: #{@movie_info.vote_average}")
+        expect(page).to have_content("Genres: Drama, Crime, Comedy")
+        expect(page).to have_content("Summary: Taisto Kasurinen is a Finnish coal miner whose father has just committed suicide and who is framed for a crime he did not commit. In jail, he starts to dream about leaving the country and starting a new life. He escapes from prison but things don't go as planned...")
+      end
+
+      it 'displays the movie runtime in hours and minutes' do
+        expect(page).to have_content("Runtime: #{@movie_info.runtime_hours} Hour(s) #{@movie_info.runtime_minutes} Minute(s)")
+      end
+
+      it "displays cast information" do
+        expect(page).to have_content('Turo Pajala as Taisto Olavi Kasurinen')
+        expect(page).to have_content('Susanna Haavisto as Irmeli Katariina Pihlaja')
+        expect(page).to_not have_content('Adam as Professor Etz')
+      end
+
+      xit "displays review informtion" do
+      end
+    end
+  end
 end

--- a/spec/poros/film_spec.rb
+++ b/spec/poros/film_spec.rb
@@ -22,18 +22,37 @@ RSpec.describe Film do
     expect(film.credits).to eq({cast: [{name: "Turo Pajala", character: "Mary Gifford"}, {name: "Frank Gerry", character: "Bird one"} ]})
   end
 
-  it "instance methods" do 
-    attrs = {
-      id: 1,
-      title: 'The Birds',
-      vote_average: 8.4,
-      runtime: 500,
-      genres: [{id: 1, name: 'Horror'}, {id: 2, name: 'Historical'}],
-      overview: "Damn these birds are mad!",
-      credits:  {cast: [{name: "Turo Pajala", character: "Mary Gifford"}, {name: "Frank Gerry", character: "Bird one"} ]}
-    }
-    film = Film.new(attrs)
+  describe 'instance methods' do
+    before :each do
+      attrs = {
+        id: 1,
+        title: 'The Birds',
+        vote_average: 8.4,
+        runtime: 500,
+        genres: [{id: 1, name: 'Horror'}, {id: 2, name: 'Historical'}],
+        overview: "Damn these birds are mad!",
+        credits:  {cast: [{name: "Turo Pajala", character: "Mary Gifford"}, {name: "Frank Gerry", character: "Bird one"} ]}
+      }
+      @film = Film.new(attrs)
+    end
+    describe 'cast' do
+      it "returns an array where the first element is an array of actor names and the second element is an array of corresponding characters" do
+        expect(@film.cast).to eq([["Turo Pajala", "Mary Gifford"], ["Frank Gerry", "Bird one"]])
+      end
+    end
 
-    expect(film.cast).to eq([["Turo Pajala", "Mary Gifford"], ["Frank Gerry", "Bird one"]])
+    describe 'runtime_hours' do
+      it "returns the number of hours in the film's runtime" do
+        expected = (@film.runtime / 60).floor
+        expect(@film.runtime_hours).to eq(expected)
+      end
+    end
+
+    describe 'runtime_minutes' do
+      it "returns the number of minutes in the film's runtime" do
+        expected = @film.runtime % 60
+        expect(@film.runtime_minutes).to eq(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
Since the movie details user story asks for the movies runtime in hours and minutes I updated our movie show page to do that.

Added two methods to the film poro runtime_hours and runtime_minutes. Tested both of them. Then used them to display like this: Runtime: 1 Hour(s) 20 Minute(s) instead of Runtime: 80

Also there are some fixes for rubocop. One rubocop warning I couldn't fix was app/controllers/friendships_controller.rb:2:3: C: Metrics/MethodLength: Method has too many lines.