### PR TITLE
Block public access & parties controller clean up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-
+  before_action :block_public_access
   helper_method :current_user
+
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,6 @@
 class DashboardController < ApplicationController
+  skip_before_action :block_public_access
+  
   def index
     return not_logged_in_notice unless current_user
 

--- a/app/controllers/discover_controller.rb
+++ b/app/controllers/discover_controller.rb
@@ -1,5 +1,4 @@
 class DiscoverController < ApplicationController
   def index
-    block_public_access
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    block_public_access
     @films = MovieDbFacade.get_films(params)
   end
 

--- a/app/controllers/parties_controller.rb
+++ b/app/controllers/parties_controller.rb
@@ -1,15 +1,12 @@
 class PartiesController < ApplicationController
-
     def new
         @party = Party.new
     end
 
     def create
-        new_party = current_user.parties.new(duration: params[:party][:duration],
-            start_time: params[:party][:start_time],
-            mdb_id: params[:party][:mdb_id],
-            movie_title: params[:party][:movie_title]
-        )
+        # params[:party][:mdb_id] = params[movie_id]
+        # party[:mdb_id] = params[:id]
+        new_party = Party.new(party_params)
         # if Party.exists?(email: user[:email])
         #   flash[:error`] = "Party already exists."
         #   render :new and return
@@ -38,8 +35,6 @@ class PartiesController < ApplicationController
     private
 
     def party_params
-      params.require(:party).permit(mdb_id, start_time, duration)
+      params.require(:party).permit(:mdb_id, :start_time, :duration)
     end
-  
-
 end

--- a/app/controllers/parties_controller.rb
+++ b/app/controllers/parties_controller.rb
@@ -1,16 +1,11 @@
 class PartiesController < ApplicationController
+
     def new
         @party = Party.new
     end
 
     def create
-        # params[:party][:mdb_id] = params[movie_id]
-        # party[:mdb_id] = params[:id]
-        new_party = Party.new(party_params)
-        # if Party.exists?(email: user[:email])
-        #   flash[:error`] = "Party already exists."
-        #   render :new and return
-        # end
+        new_party = current_user.parties.new(party_params)
         if new_party.save
             new_party.viewers.create(
                 user: current_user,
@@ -35,6 +30,6 @@ class PartiesController < ApplicationController
     private
 
     def party_params
-      params.require(:party).permit(:mdb_id, :start_time, :duration)
+      params.require(:party).permit(:mdb_id, :movie_title, :start_time, :duration)
     end
 end

--- a/app/controllers/parties_controller.rb
+++ b/app/controllers/parties_controller.rb
@@ -1,5 +1,4 @@
 class PartiesController < ApplicationController
-
     def new
         @party = Party.new
     end
@@ -7,20 +6,15 @@ class PartiesController < ApplicationController
     def create
         new_party = current_user.parties.new(party_params)
         if new_party.save
-            new_party.viewers.create(
-                user: current_user,
-                status: 'host'
-            )
-            params[:party][:viewers].each do |friend|
-                unless friend == ""
+            new_party.viewers.create(user: current_user, status: 'host')
+            party_viewers_params.each do |friend_id|
+                unless friend_id.blank?
                     new_party.viewers.create(
-                        user_id: friend,
-                        status: 'guest'
-                    )
+                        user_id: friend_id,
+                        status: 'guest')
                 end
             end
-            flash[:success] = "Yo! You started a party!"
-            redirect_to dashboard_path
+            redirect_to dashboard_path, notice: 'Yo! You started a party!'
         else
             flash[:error] = "Dun Dun DUUUUN! try again"
             render :new
@@ -30,6 +24,10 @@ class PartiesController < ApplicationController
     private
 
     def party_params
-      params.require(:party).permit(:mdb_id, :movie_title, :start_time, :duration)
+        params.require(:party).permit(:mdb_id, :movie_title, :start_time, :duration)
+    end
+
+    def party_viewers_params
+        params.require(:party).permit(:viewers)
     end
 end

--- a/app/controllers/parties_controller.rb
+++ b/app/controllers/parties_controller.rb
@@ -9,9 +9,7 @@ class PartiesController < ApplicationController
             new_party.viewers.create(user: current_user, status: 'host')
             party_viewers_params.each do |friend_id|
                 unless friend_id.blank?
-                    new_party.viewers.create(
-                        user_id: friend_id,
-                        status: 'guest')
+                    new_party.viewers.create(user_id: friend_id, status: 'guest')
                 end
             end
             redirect_to dashboard_path, notice: 'Yo! You started a party!'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+  skip_before_action :block_public_access
   def new
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  skip_before_action :block_public_access
+  
   def new
     @user = User.new
   end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,5 @@
 class WelcomeController < ApplicationController
+  skip_before_action :block_public_access
   def index
     redirect_to dashboard_path if current_user
   end

--- a/spec/features/movies/show_spec.rb
+++ b/spec/features/movies/show_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-
 RSpec.describe 'movies show page', type: :feature do
   describe "happy path", :vcr do
     # HOW DO WE USE ONE VCR CASSETTE FOR ALL TESTS? VCR.use_cassette aint workin
@@ -9,7 +8,6 @@ RSpec.describe 'movies show page', type: :feature do
       mdb_id = 10719
       visit movie_path(mdb_id)
     end
-
     it "user visits movie show page" do
       expect(page).to have_content('Elf')
       expect(page).to have_content('Vote Average: 6.6')
@@ -20,17 +18,14 @@ RSpec.describe 'movies show page', type: :feature do
       expect(page).to have_content('Zooey Deschanel as Jovie')
       expect(page).to_not have_content('Adam as Professor Etz')
     end
-
     it 'displays the total reviews count' do
       expect(page).to have_content("Total Reviews Count: 3")
     end
-
     it 'only displays the first 10 cast members' do
       within '#cast' do
         expect(page.all(:css, '.cast-member').size).to eq(10)
       end
     end
-
     it 'it displays the review author and rating', :vcr do
       within '#reviews' do
         expect(page.all(:css, '.review').size).to eq(3)
@@ -38,15 +33,9 @@ RSpec.describe 'movies show page', type: :feature do
         expect(page).to have_content("Rating: 9.0")
       end
     end
-
     it "displays a link to create a new party" do
-      @user = create(:user, email: 'test@email.com')
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
-
       expect(page).to have_button('Create a Viewing Party')
-
       click_on 'Create a Viewing Party'
-
       expect(current_path).to eq(new_party_path)
     end
   end

--- a/spec/features/movies/show_spec.rb
+++ b/spec/features/movies/show_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'movies show page', type: :feature do
   describe "happy path", :vcr do
     # HOW DO WE USE ONE VCR CASSETTE FOR ALL TESTS? VCR.use_cassette aint workin
     before(:each) do
+      @user = create(:user, email: 'test@email.com')
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
       mdb_id = 10719
       visit movie_path(mdb_id)
     end

--- a/spec/features/parties/new_spec.rb
+++ b/spec/features/parties/new_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe "new party page" do
 
     describe "happy path" do
         it "displays movie details and form", :vcr do
+            @user = create(:user, email: 'test@email.com')
+            allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
             mdb_id = 10719
             visit movie_path(mdb_id)
 
@@ -18,6 +21,9 @@ RSpec.describe "new party page" do
         end 
 
         it "can create new viewing party", :vcr do
+            @user = create(:user, email: 'test@email.com')
+            allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+            
             mdb_id = 10719
             visit movie_path(mdb_id)
             click_button('Create a Viewing Party')
@@ -28,32 +34,7 @@ RSpec.describe "new party page" do
             click_button 'Submit'
 
             expect(current_path).to eq(dashboard_path)
-        end
-
-        it "can add friends and create viewing party", :vcr do
-            jerry = @user.friends.create(email: 'jerry@example.com', name: 'jerry', password: "xyz")
-            achmed = @user.friends.create(email: 'achmed@example.com', name: 'Achmed', password: "xyz")
-
-
-            mdb_id = 10719
-            movie_title = "Elf"
-            visit movie_path(mdb_id)
-            click_button('Create a Viewing Party')
-            duration = 200
-            starttime = '2021-03-01 01:00:00 UTC'
-
-            fill_in :duration, with: duration
-            fill_in :start_time, with: starttime
-            find(:css, "#party_viewers_#{jerry.id}").set(true)
-
-            click_button 'Submit'
-
-            expect(current_path).to eq(dashboard_path)
-                        
-            within(first('.viewing-parties')) do
-                expect(page).to have_content(starttime)
-                expect(page).to have_content(movie_title)
-            end
+            expect(page).to have_content("Yo! You started a party!")
         end
 
 

--- a/spec/features/parties/new_spec.rb
+++ b/spec/features/parties/new_spec.rb
@@ -8,9 +8,6 @@ RSpec.describe "new party page" do
 
     describe "happy path" do
         it "displays movie details and form", :vcr do
-            @user = create(:user, email: 'test@email.com')
-            allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
-
             mdb_id = 10719
             visit movie_path(mdb_id)
 
@@ -21,16 +18,8 @@ RSpec.describe "new party page" do
         end 
 
         it "can create new viewing party", :vcr do
-            @user = create(:user, email: 'test@email.com')
-            visit login_path
-            fill_in :email, with: 'test@email.com'
-            fill_in :password, with: 'password'
-            click_button 'Log In'
-            
             mdb_id = 10719
-
             visit movie_path(mdb_id)
-            
             click_button('Create a Viewing Party')
 
             fill_in :duration, with: 200
@@ -39,9 +28,32 @@ RSpec.describe "new party page" do
             click_button 'Submit'
 
             expect(current_path).to eq(dashboard_path)
-            
-            # Next up...get viewers added during Party creation
-            # expect(page).to have_content("Yo! You started a party!")
+        end
+
+        it "can add friends and create viewing party", :vcr do
+            jerry = @user.friends.create(email: 'jerry@example.com', name: 'jerry', password: "xyz")
+            achmed = @user.friends.create(email: 'achmed@example.com', name: 'Achmed', password: "xyz")
+
+
+            mdb_id = 10719
+            movie_title = "Elf"
+            visit movie_path(mdb_id)
+            click_button('Create a Viewing Party')
+            duration = 200
+            starttime = '2021-03-01 01:00:00 UTC'
+
+            fill_in :duration, with: duration
+            fill_in :start_time, with: starttime
+            find(:css, "#party_viewers_#{jerry.id}").set(true)
+
+            click_button 'Submit'
+
+            expect(current_path).to eq(dashboard_path)
+                        
+            within(first('.viewing-parties')) do
+                expect(page).to have_content(starttime)
+                expect(page).to have_content(movie_title)
+            end
         end
 
 

--- a/spec/features/parties/new_spec.rb
+++ b/spec/features/parties/new_spec.rb
@@ -22,10 +22,15 @@ RSpec.describe "new party page" do
 
         it "can create new viewing party", :vcr do
             @user = create(:user, email: 'test@email.com')
-            allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+            visit login_path
+            fill_in :email, with: 'test@email.com'
+            fill_in :password, with: 'password'
+            click_button 'Log In'
             
             mdb_id = 10719
+
             visit movie_path(mdb_id)
+            
             click_button('Create a Viewing Party')
 
             fill_in :duration, with: 200
@@ -34,7 +39,9 @@ RSpec.describe "new party page" do
             click_button 'Submit'
 
             expect(current_path).to eq(dashboard_path)
-            expect(page).to have_content("Yo! You started a party!")
+            
+            # Next up...get viewers added during Party creation
+            # expect(page).to have_content("Yo! You started a party!")
         end
 
 


### PR DESCRIPTION
- Moved block_public_access to a before_action call in ApplicationController
  - skip in 'public' actions
- Get strong params working in the parties controller
- Condense create action in parties controller
- In movie show spec, move ApplicationController :current_user stub to before(:each) block to play nice with block_public_access implementation