### PR TITLE
Fix for removed all_friends in dshboard

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -7,7 +7,7 @@
 
   <%= render partial: '/users/add_friend' %>
 
-  <% unless current_user.friends.empty? %>
+  <% unless current_user.all_friends.empty? %>
     <ul>
       <% current_user.all_friends.each do |friend| %>
         <li><%= friend.name %></li>


### PR DESCRIPTION
one line fix on dashboard - last pr had remove all_friends and replaced with friends Need to check for both firends and inverse friends.