### PR TITLE
Resolve duplicate friend bug

### DIFF
--- a/app/facades/friendships_facade.rb
+++ b/app/facades/friendships_facade.rb
@@ -3,7 +3,7 @@ class FriendshipsFacade
     def add_friendship(current_user, friend)
       if friend.id == current_user.id
         'Failed Friend Request. Cannot Friend Yourself!'
-      elsif current_user.friends.include?(friend)
+      elsif current_user.all_friends.include?(friend)
         "Failed Friend Request. Already Friended User: #{friend.name}"
       else
         current_user.friendships.create!({ friend_id: friend.id })

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,5 +19,4 @@ class User < ApplicationRecord
   def all_friends
     friends + inverse_friends
   end
-
 end

--- a/app/views/movies/show.html.erb
+++ b/app/views/movies/show.html.erb
@@ -1,5 +1,5 @@
 <h1><%= @movie.title %></h1>
-<%= button_to 'Create a Viewing Party', new_party_path, method: :get, params: {movie: @movie.title, movie_id: params[:id], runtime: @movie.runtime } %>
+<%= button_to 'Create a Viewing Party', new_party_path, method: :get, params: { movie: @movie.title, movie_id: params[:id], runtime: @movie.runtime } %>
 
 <h2>Movie Details</h2>
 


### PR DESCRIPTION
Minor bug it turns out, quick hotfix ahead of a possible extension/refactor that @aetzion1 would like to work on:
- use `user.all_friends` in FriendshipFacade flow control to recognize friends + inverse_friends instead of just `user.friends`

Closes #85 